### PR TITLE
AWS S3를 활용한 BinaryContentStroage 고도화

### DIFF
--- a/src/main/java/com/sprint/mission/discodeit/storage/s3/Properties.java
+++ b/src/main/java/com/sprint/mission/discodeit/storage/s3/Properties.java
@@ -1,46 +1,19 @@
 package com.sprint.mission.discodeit.storage.s3;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationProperties(prefix = "discodeit.storage.s3")
+@Getter
+@Setter
 public class Properties {
 
     private String accessKey;
     private String secretKey;
     private String region;
     private String bucket;
-
-    public String getAccessKey() {
-        return accessKey;
-    }
-
-    public void setAccessKey(String accessKey) {
-        this.accessKey = accessKey;
-    }
-
-    public String getSecretKey() {
-        return secretKey;
-    }
-
-    public void setSecretKey(String secretKey) {
-        this.secretKey = secretKey;
-    }
-
-    public String getRegion() {
-        return region;
-    }
-
-    public void setRegion(String region) {
-        this.region = region;
-    }
-
-    public String getBucket() {
-        return bucket;
-    }
-
-    public void setBucket(String bucket) {
-        this.bucket = bucket;
-    }
+    private Long presignedUrlExpiration;
 }

--- a/src/main/java/com/sprint/mission/discodeit/storage/s3/S3BinaryContentStorage.java
+++ b/src/main/java/com/sprint/mission/discodeit/storage/s3/S3BinaryContentStorage.java
@@ -1,0 +1,116 @@
+package com.sprint.mission.discodeit.storage.s3;
+
+import com.sprint.mission.discodeit.dto.data.BinaryContentDto;
+import com.sprint.mission.discodeit.storage.BinaryContentStorage;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.UUID;
+
+@Component
+@ConditionalOnProperty(name = "discodeit.storage.type", havingValue = "s3")
+public class S3BinaryContentStorage implements BinaryContentStorage {
+    private Properties properties;
+
+    public S3BinaryContentStorage(Properties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public UUID put(UUID binaryContentId, byte[] bytes) {
+        String key = binaryContentId.toString();
+
+        try {
+            getS3Client().putObject(
+                    PutObjectRequest.builder()
+                            .bucket(properties.getBucket())
+                            .key(key)
+                            .build(),
+                    RequestBody.fromBytes(bytes)
+            );
+        } catch (SdkClientException e) {
+            throw new RuntimeException("S3 upload failed", e);
+        }
+
+
+        return binaryContentId;
+    }
+
+    @Override
+    public InputStream get(UUID binaryContentId) {
+        try {
+            return getS3Client().getObject(
+                    GetObjectRequest.builder()
+                            .bucket(properties.getBucket())
+                            .key(binaryContentId.toString())
+                            .build()
+            );
+        } catch (SdkClientException e) {
+            e.printStackTrace();
+            throw new RuntimeException("S3 get failed", e);
+        }
+    }
+
+    @Override
+    public ResponseEntity<?> download(BinaryContentDto metaData) {
+        String key = metaData.id().toString();
+        S3Presigner presigner = generatePresignedUrl();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(properties.getPresignedUrlExpiration()))
+                .getObjectRequest(GetObjectRequest.builder()
+                        .bucket(properties.getBucket())
+                        .key(key)
+                        .build())
+                .build();
+
+        String presignedUrl = presigner.presignGetObject(presignRequest).url().toString();
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header(HttpHeaders.LOCATION, presignedUrl)
+                .build();
+    }
+
+
+    public S3Client getS3Client() {
+        return S3Client.builder()
+                .region(Region.of(properties.getRegion()))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(
+                                        properties.getAccessKey(),
+                                        properties.getSecretKey()
+                                )
+                        )
+                )
+                .build();
+    }
+
+    public S3Presigner generatePresignedUrl() {
+        return S3Presigner.builder()
+                .region(Region.of(properties.getRegion()))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(
+                                        properties.getAccessKey(),
+                                        properties.getSecretKey()
+                                )
+                        )
+                ).build();
+    }
+}

--- a/src/test/java/com/sprint/mission/discodeit/storage/s3/S3BinaryContentStorageTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/storage/s3/S3BinaryContentStorageTest.java
@@ -1,0 +1,172 @@
+package com.sprint.mission.discodeit.storage.s3;
+
+import com.sprint.mission.discodeit.dto.data.BinaryContentDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class S3BinaryContentStorageTest {
+
+    private Properties properties;
+    private S3BinaryContentStorage s3BinaryContentStorage;
+    private S3Client s3Client;
+
+    @BeforeEach
+    void setUp() {
+        // given
+        properties = new Properties();
+        properties.setBucket("test-bucket");
+        properties.setRegion("ap-northeast-2");
+        properties.setAccessKey("access-key");
+        properties.setSecretKey("secret-key");
+        properties.setPresignedUrlExpiration(600L);
+
+        s3Client = mock(S3Client.class);
+
+        s3BinaryContentStorage = new S3BinaryContentStorage(properties) {
+            @Override
+            public S3Client getS3Client() {
+                return s3Client;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("bucket, key 확인 및 반환 값 검증")
+    void putSuccess() {
+        // given
+        UUID binaryContentId = UUID.randomUUID();
+        byte[] bytes = new byte[1024];
+
+        // when
+        UUID result = s3BinaryContentStorage.put(binaryContentId, bytes);
+
+        // then
+        assertEquals(binaryContentId, result, "put 메서드는 입력한 UUID를 그대로 반환해야 함");
+
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        ArgumentCaptor<RequestBody> bodyCaptor = ArgumentCaptor.forClass(RequestBody.class);
+        verify(s3Client, times(1)).putObject(requestCaptor.capture(), bodyCaptor.capture());
+
+        PutObjectRequest capturedRequest = requestCaptor.getValue();
+        assertEquals("test-bucket", capturedRequest.bucket(), "버킷 이름 동일해야 함");
+        assertEquals(binaryContentId.toString(), capturedRequest.key(), "S3 key는 UUID 문자열이어야 험");
+    }
+
+    @Test
+    @DisplayName("put 실패 시 RuntimeException 발생 테스트")
+    void putShouldThrowRuntimeExceptionWhenS3Fail() {
+        // given
+        UUID binaryContentId = UUID.randomUUID();
+        byte[] bytes = new byte[1024];
+
+        doThrow(new RuntimeException("S3 upload failed"))
+                .when(s3Client)
+                .putObject(any(PutObjectRequest.class), any(RequestBody.class));
+
+        // when & then
+        RuntimeException exception = org.junit.jupiter.api.Assertions.assertThrows(
+                RuntimeException.class,
+                () -> s3BinaryContentStorage.put(binaryContentId, bytes)
+        );
+        assertEquals("S3 upload failed", exception.getMessage());
+    }
+
+
+    @Test
+    void getSuccess() throws IOException {
+        // given
+        UUID binaryContentId = UUID.randomUUID();
+        byte[] bytes = "테스트 데이터".getBytes();
+
+        ResponseInputStream<GetObjectResponse> mockResponseInputStream =
+                new ResponseInputStream<>(
+                        GetObjectResponse.builder().contentLength((long) bytes.length).build(),
+                        new ByteArrayInputStream(bytes)
+                );
+
+        when(s3Client.getObject(any(GetObjectRequest.class)))
+                .thenReturn(mockResponseInputStream);
+
+        // when
+        InputStream inputStream = s3BinaryContentStorage.get(binaryContentId);
+        byte[] actualData = inputStream.readAllBytes();
+
+        // then
+        assertNotNull(inputStream);
+        assertArrayEquals(bytes, actualData);
+    }
+
+    @Test
+    @DisplayName("get 실패 테스트 - S3 예외 발생")
+    void getShouldThrowRuntimeExceptionWhenS3Fail() {
+        UUID binaryContentId = UUID.randomUUID();
+
+        when(s3Client.getObject(any(GetObjectRequest.class)))
+                .thenThrow(SdkClientException.builder().message("S3 get failed").build());
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> s3BinaryContentStorage.get(binaryContentId));
+
+        assertEquals("S3 get failed", exception.getCause().getMessage());
+    }
+
+    @Test
+    @DisplayName("다운로드 성공 - presignedUrl 반환")
+    void downloadSuccess() throws MalformedURLException {
+        // given
+        UUID binaryContentId = UUID.randomUUID();
+        BinaryContentDto metaData = new BinaryContentDto(
+                binaryContentId,
+                "test.txt",
+                1024L,
+                "text/plain"
+        );
+
+        S3Presigner mockPresigner = mock(S3Presigner.class);
+        PresignedGetObjectRequest mockPresignedRequest = mock(PresignedGetObjectRequest.class);
+
+        when(mockPresignedRequest.url()).thenReturn(new URL("https://s3.mock/test.txt"));
+        when(mockPresigner.presignGetObject(any(GetObjectPresignRequest.class)))
+                .thenReturn(mockPresignedRequest);
+
+        // S3BinaryContentStorage 익명클래스 오버라이드
+        S3BinaryContentStorage storage = new S3BinaryContentStorage(properties) {
+            @Override
+            public S3Presigner generatePresignedUrl() {
+                return mockPresigner;
+            }
+        };
+
+        // when
+        var response = storage.download(metaData);
+
+        // then
+        assertNotNull(response, "ResponseEntity는 null이면 안 됨");
+        assertEquals(302, response.getStatusCode().value(), "HTTP 상태코드는 302 FOUND 이어야 함");
+        assertEquals("https://s3.mock/test.txt",
+                response.getHeaders().getLocation().toString(),
+                "Location 헤더에 presigned URL이 담겨야 함");
+    }
+}


### PR DESCRIPTION

- [x]  앞서 작성한 테스트 메소드를 참고해 `S3BinaryContentStorage`를 구현하세요.
    - 클래스 다이어그램
        
        [[fxlj0hb8j-image.png](https://bakey-api.codeit.kr/api/files/resource?root=static&seqId=13951&version=1&directory=/fxlj0hb8j-image.png&name=fxlj0hb8j-image.png)](https://bakey-api.codeit.kr/api/files/resource?root=static&seqId=13951&version=1&directory=/fxlj0hb8j-image.png&name=fxlj0hb8j-image.png)
        
- [x]  `discodeit.storage.type` 값이 `s3`인 경우에만 Bean으로 등록되어야 합니다.
- [x]  `S3BinaryContentStorageTest`를 함께 작성하면서 구현하세요.
- [x]  `BinaryContentStorage` 설정을 유연하게 제어할 수 있도록 `application.yaml`을 수정하세요.
    
    ```yaml
    
    discodeit:
      storage:
        type: local    type: ${STORAGE_TYPE:local}  # local | s3 (기본값: local)
        local:
          root-path: .discodeit/storage      root-path: ${STORAGE_LOCAL_ROOT_PATH:.discodeit/storage}
        s3:
          access-key: ${AWS_S3_ACCESS_KEY}
          secret-key: ${AWS_S3_SECRET_KEY}
          region: ${AWS_S3_REGION}
          bucket: ${AWS_S3_BUCKET}
          presigned-url-expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:600} # (기본값: 10분)
    ```
    
    - [x]  AWS 관련 정보는 형상관리하면 안되므로 `.env` 파일에 작성된 값을 임포트하는 방식으로 설정하세요.
    - [x]  Docker Compose에서도 위 설정을 주입할 수 있도록 수정하세요.
- [x]  `download` 메소드는 `PresignedUrl`을 활용해 리다이렉트하는 방식으로 구현하세요.